### PR TITLE
Check if hook exists and don't reinstall.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-hook",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Helper module for installing hooks into NativeScript projects",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/NativeScript/nativescript-hook.git"
   },
   "dependencies": {
+    "glob": "^6.0.1",
     "mkdirp": "^0.5.1"
   }
 }


### PR DESCRIPTION
Installing a hook checks if the hook script already exists (those should be kept in source control), and does nothing in that case.

Added a dependency to `glob`, so that we do a fuzzy match and handle cases like renaming a hook script like `nativescript-dev-typescript.js` to `20-nativescript-dev-typescript.js` in order to enforce order between several hooks. Example:
https://github.com/NativeScript/sample-ng-todomvc/tree/master/hooks/before-prepare

Note: the `glob` dependency is set to `*` so that we try to use any glob version that the user has installed. I'm not sure if that's the right thing to do here.