### PR TITLE
Use and process.env.INIT_CWD to find path to app for npm5 local installs

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ function generateHookName(pkg, hook) {
 }
 
 function findProjectDir(pkgdir) {
+	if (process.env.INIT_CWD) {
+		return process.env.INIT_CWD;
+	}
+
 	var candidateDir = pkgdir;
 
 	while (true) {


### PR DESCRIPTION
Installing from local directory, npm will set process.env.INIT_CWD to the app path, and symlink to the postinstall scripts will be resolved in __dirname