### PR TITLE
feat: Print directory where the hook has already been installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function findProjectDir(pkgdir) {
 		if (path.basename(candidateDir) === 'node_modules') {
 			continue;
 		}
-		
+
 		if (_isNativeScriptAppRoot(candidateDir)) {
 			return candidateDir;
 		}
@@ -94,7 +94,7 @@ function postinstall(pkgdir) {
 			mkdirp.sync(hookDir);
 		}
 		if (hookInstalled(hookDir, pkg, hook)) {
-			console.log('Hook already installed: ' + pkg.name);
+			console.log(`Hook already installed: ${pkg.name} at location: ${hookDir}`);
 			return;
 		}
 		var hookFileName = generateHookName(pkg, hook);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-hook",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Helper module for installing hooks into NativeScript projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently when the plugin has already been installed users receive message:
`Hook already installed: <name>`
But the location where the hook had already been installed is not printed anywhere. Print it in order to determine easily in case the plugin had not detected correctly the location where the hook should have been installed.