### PR TITLE
Ability to define a custom hook name

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,20 @@ And finally, when installing in-process hooks through this module, you need to e
   },
 }
 ```
+
+You have the ability to define a custom name to your hook in `package.json`, this attribute is optional and defaults to the plugin package name:
+```json
+{
+  "nativescript": {
+    "hooks": [
+      {
+        "type": "after-prepare",
+        "script": "lib/after-prepare.js",
+        "name": "my-custom-hook"
+      }
+    ]
+  },
+}
+```
+
+

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var mkdirp = require('mkdirp');
 var glob = require('glob');
 
 function generateHookName(pkg, hook) {
-	return pkg.name + '.js';
+	return (hook.name || pkg.name) + '.js';
 }
 
 function findProjectDir(pkgdir) {


### PR DESCRIPTION
I'm building a bunch of plugin and wanted to namespace them within my company name, the way `@angular` or `@ngx` does.

The issue I'm facing is that if I name my plugin `@mycompany/core`, `@mycompany/core.js` will not be a valid hook name (nesting issue) and breaks the installation.

I'm adding the ability to define a `name` property on the hook definition in `package.json` so we can overwrite the default package name if required. (ex: naming the hook: `mycompany-core.js`)