### PR TITLE
fix: works with npm/yarn/pnpm link

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,10 @@ function findProjectDir(pkgdir) {
     return process.env.INIT_CWD;
   }
 
-  var candidateDir = pkgdir;
+  var candidateDir = process.cwd();
   var oldCandidateDir = null;
 
   while (true) {
-    candidateDir = path.dirname(candidateDir);
     if (oldCandidateDir === candidateDir) {
       return;
     }
@@ -47,6 +46,7 @@ function findProjectDir(pkgdir) {
     }
 
     oldCandidateDir = candidateDir;
+    candidateDir = path.dirname(candidateDir);
   }
 }
 


### PR DESCRIPTION
Right now we use __dirname to find parent root project. But this wont work in a link situation where __dirname will point to the real folder of the plugin. Now we use `process.cwd()` which will work in whatever folder we are inside the project (which is what we want). plus it will be much faster as most of the time `process.cwd()` will already be the app root folder